### PR TITLE
Use object instances instead of root objects for exporting

### DIFF
--- a/blender_plugin/io_dif/export_dif.py
+++ b/blender_plugin/io_dif/export_dif.py
@@ -225,6 +225,7 @@ def get_offset(depsgraph, applymodifiers=True):
                     minv[i] = vert.co[i]
                 if maxv[i] < vert.co[i]:
                     maxv[i] = vert.co[i]
+        ob_eval.to_mesh_clear()
 
     off = [((maxv[i] - minv[i]) / 2) + 50 for i in range(0, 3)]
     return off
@@ -289,6 +290,8 @@ def build_pathed_interior(ob: Object, marker_ob: Curve, offset, flip, double):
 
     for pt in marker_pts:
         marker_list.push_marker(pt.co, msToNext, initialPathPosition)
+
+    ob.to_mesh_clear()
 
     return (dif, marker_list)
 
@@ -431,6 +434,7 @@ def save(
         try:
             me = ob_eval.to_mesh()
         except RuntimeError:
+            print("Skipping mesh due to bad eval")
             continue
 
         if dif_props.interior_type == "static_interior":
@@ -438,9 +442,9 @@ def save(
             try:
                 save_mesh(ob_eval, me, off, flip, double)
             except:
-                print("Skipping mesh")
-                continue
+                print("Skipping mesh due to issue while saving")
             
+        ob_eval.to_mesh_clear()
 
         if dif_props.interior_type == "pathed_interior":
             mp_list.append((ob_eval, dif_props.marker_path))

--- a/blender_plugin/io_dif/export_dif.py
+++ b/blender_plugin/io_dif/export_dif.py
@@ -344,10 +344,6 @@ def save(
         nonlocal tris, difbuilder
 
         mesh_triangulate(mesh)
-        
-        print(mesh)
-        print(mesh.uv_layers)
-        print(mesh.uv_layers.items())
 
         mesh_verts = mesh.vertices
 

--- a/blender_plugin/io_dif/export_dif.py
+++ b/blender_plugin/io_dif/export_dif.py
@@ -411,7 +411,7 @@ def save(
     
     def is_object_instance_visible(object_instance):
         # For instanced objects we check visibility of their instancer (more accurately: check
-        # vsibility status of the original object corresponding to the instancer).
+        # visibility status of the original object corresponding to the instancer).
         if object_instance.parent:
             return object_instance.parent.original.visible_get()
         # For non-instanced objects we check visibility state of the original object.

--- a/blender_plugin/io_dif/export_dif.py
+++ b/blender_plugin/io_dif/export_dif.py
@@ -159,6 +159,9 @@ class DifBuilder:
 
         mat = ctypes.c_char_p(material.encode("ascii"))
 
+        #Debug lines 
+        # print((p3arr, p2arr, p1arr, uv3arr, uv2arr, uv1arr, narr, mat))
+        #Cont
         difbuilderlib.add_triangle(
             self.__ptr__, p3arr, p2arr, p1arr, uv3arr, uv2arr, uv1arr, narr, mat
         )
@@ -179,7 +182,21 @@ class DifBuilder:
         )
 
     def build(self):
-        return Dif(difbuilderlib.build(self.__ptr__))
+        
+        try:
+            built = difbuilderlib.build(self.__ptr__)
+        except OSError as e:
+            print(e)
+            print(e.winerror)
+            print(e.strerror)
+            raise e
+        try:
+            return Dif(built)
+        except OSError as e:
+            print(e)
+            print(e.winerror)
+            print(e.strerror)
+            raise e
 
 
 def mesh_triangulate(me):
@@ -328,7 +345,7 @@ def save(
 ):
     import bpy
     import bmesh
-    
+
     #bpy.ops.object.duplicates_make_real()
     
     #def get_objects():
@@ -393,6 +410,9 @@ def save(
                 if poly.material_index != None
                 else "NULL"
             )
+
+            # Debug
+            print((p1, p2, p3, uv1, uv2, uv3, n, material))
 
             if not flip:
                 difbuilder.add_triangle(p1, p2, p3, uv1, uv2, uv3, n, material)
@@ -462,6 +482,7 @@ def save(
             try:
                 save_mesh(ob_eval, me, off, flip, double)
             except:
+                print("Skipping mesh")
                 continue
             
 
@@ -472,6 +493,10 @@ def save(
 
     for (mp, curve) in mp_list:
         mp_difs.append(build_pathed_interior(mp, curve, off, flip, double))
+
+    #DEBUG
+    print("Generated tris:")
+    print(tris)
 
     if tris != 0:
         for i in range(0, len(builders)):


### PR DESCRIPTION
Modifies io_dif to export all applicable instances of objects instead of just root objects. This allows for more advanced use of geometry nodes.