### PR TITLE
Allow building on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,25 @@ project(DifBuilderLib)
 
 add_subdirectory("3rdparty/DifBuilder")
 
-set(CMAKE_CXX_FLAGS "/MT")
-set(CMAKE_CXX_FLAGS_RELEASE "/MT")
-set(CMAKE_CXX_FLAGS_DEBUG "/MTd /FS")
+if (UNIX)
+    set(CMAKE_CXX_FLAGS "-std=c++11")
+else()
+    set(CMAKE_CXX_FLAGS "/MT")
+    set(CMAKE_CXX_FLAGS_RELEASE "/MT")
+    set(CMAKE_CXX_FLAGS_DEBUG "/MTd /FS")
+endif()
 
 set(SOURCE_FILES DifBuilderLib.cpp)
 add_library(DifBuilderLib SHARED ${SOURCE_FILES})
 
-set_target_properties(DifBuilder PROPERTIES COMPILE_FLAGS "/Od /Ob0") # Disable optimizations cause it breaks
-set_target_properties(DifBuilderLib PROPERTIES COMPILE_FLAGS "/Od /Ob0")
+if (UNIX)
+    set_target_properties(DifBuilder PROPERTIES COMPILE_FLAGS "-O0") # Disable optimizations cause it breaks
+    set_target_properties(DifBuilderLib PROPERTIES COMPILE_FLAGS "-O0")
+    set_target_properties(DifBuilderLib PROPERTIES PREFIX "")
+else ()
+    set_target_properties(DifBuilder PROPERTIES COMPILE_FLAGS "/Od /Ob0") # Disable optimizations cause it breaks
+    set_target_properties(DifBuilderLib PROPERTIES COMPILE_FLAGS "/Od /Ob0")
+endif()
 include_directories(3rdparty/DifBuilder/include)
 include_directories(3rdparty/DifBuilder/3rdparty/)
 include_directories(3rdparty/DifBuilder/3rdparty/Dif)

--- a/DifBuilderLib.h
+++ b/DifBuilderLib.h
@@ -4,7 +4,7 @@
 #if _MSC_VER
 #define PLUGIN_API __declspec(dllexport)
 #else
-#define PLUGIN_API
+#define PLUGIN_API __attribute__((visibility("default")))
 #endif
 
 extern "C"

--- a/blender_plugin/io_dif/__init__.py
+++ b/blender_plugin/io_dif/__init__.py
@@ -23,6 +23,7 @@ if "bpy" in locals():
         importlib.reload(import_csx)
 
 import os
+import platform
 import bpy
 from bpy.props import (
     BoolProperty,
@@ -311,9 +312,10 @@ def register():
     bpy.utils.register_class(InteriorKVP)
     bpy.utils.register_class(InteriorSettings)
 
-    dllpath = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dll"
-    )
+    if platform.system() == "Windows":
+        dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dll")
+    elif platform.system() == "Darwin":
+        dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dylib")
     if not os.path.isfile(dllpath):
         raise Exception(
             "There was an error loading the necessary dll required for dif export. Please download the plugin from the proper location: https://github.com/RandomityGuy/io_dif/releases"

--- a/blender_plugin/io_dif/export_dif.py
+++ b/blender_plugin/io_dif/export_dif.py
@@ -3,13 +3,17 @@ from typing import Dict
 import bpy
 import ctypes
 import os
+import platform
 from pathlib import Path
 
 from bpy.types import Curve, Image, Material, Mesh, Object, ShaderNodeTexImage
 from bpy_extras.wm_utils.progress_report import ProgressReport, ProgressReportSubstep
 from mathutils import Quaternion, Vector
 
-dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dll")
+if platform.system() == "Windows":
+    dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dll")
+elif platform.system() == "Darwin":
+    dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dylib")
 difbuilderlib = None
 try:
     difbuilderlib = ctypes.CDLL(dllpath)


### PR DESCRIPTION
It just builds (TM) with the provided patches, then you can drop the dylib in the blender install just like you would the dll. 