### PR TITLE
Support building and running on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,14 @@ endif()
 set(SOURCE_FILES DifBuilderLib.cpp)
 add_library(DifBuilderLib SHARED ${SOURCE_FILES})
 
-if (UNIX)
+if (UNIX AND APPLE)
     set_target_properties(DifBuilder PROPERTIES COMPILE_FLAGS "-O0") # Disable optimizations cause it breaks
     set_target_properties(DifBuilderLib PROPERTIES COMPILE_FLAGS "-O0")
+    set_target_properties(DifBuilderLib PROPERTIES PREFIX "")
+elseif (UNIX AND NOT APPLE)
+    set_target_properties(Dif PROPERTIES COMPILE_FLAGS "-O0 -fPIC")
+    set_target_properties(DifBuilder PROPERTIES COMPILE_FLAGS "-O0 -fPIC") # Disable optimizations cause it breaks
+    set_target_properties(DifBuilderLib PROPERTIES COMPILE_FLAGS "-O0 -fPIC")
     set_target_properties(DifBuilderLib PROPERTIES PREFIX "")
 else ()
     set_target_properties(DifBuilder PROPERTIES COMPILE_FLAGS "/Od /Ob0") # Disable optimizations cause it breaks

--- a/blender_plugin/io_dif/__init__.py
+++ b/blender_plugin/io_dif/__init__.py
@@ -320,6 +320,10 @@ def register():
         dllpath = os.path.join(
             os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dylib"
         )
+    elif platform.system() == "Linux":
+        dllpath = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.so"
+        )
     if not os.path.isfile(dllpath):
         raise Exception(
             "There was an error loading the necessary dll required for dif export. Please download the plugin from the proper location: https://github.com/RandomityGuy/io_dif/releases"

--- a/blender_plugin/io_dif/export_dif.py
+++ b/blender_plugin/io_dif/export_dif.py
@@ -14,6 +14,8 @@ if platform.system() == "Windows":
     dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dll")
 elif platform.system() == "Darwin":
     dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.dylib")
+elif platform.system() == "Linux":
+    dllpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "DifBuilderLib.so")
 difbuilderlib = None
 try:
     difbuilderlib = ctypes.CDLL(dllpath)


### PR DESCRIPTION
Additions to build and run on Linux.

Tested on Debian 11, GCC 10.2, Blender 2.83.5. Plugin installed and successfully imported TGE 1.4 dif interior model into Blender.